### PR TITLE
Let other engines subscribe on received documents

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/nuts-foundation/nuts-crypto/log"
+	"github.com/nuts-foundation/nuts-network/pkg/documentlog"
 	"github.com/nuts-foundation/nuts-network/pkg/model"
 	"io"
 	"io/ioutil"
@@ -34,6 +36,11 @@ import (
 type HttpClient struct {
 	ServerAddress string
 	Timeout       time.Duration
+}
+
+func (hb HttpClient) Subscribe(documentType string) documentlog.DocumentQueue {
+	log.Logger().Error("Subscribe() is not supported client mode.")
+	return nil
 }
 
 func (hb HttpClient) GetDocumentContents(hash model.Hash) (io.ReadCloser, error) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -96,3 +96,11 @@ func TestHttpClient_ListDocuments(t *testing.T) {
 		assert.Equal(t, doc2.Type, documents[1].Type)
 	})
 }
+
+func TestHttpClient_Subscribe(t *testing.T) {
+	t.Run("not supported", func(t *testing.T) {
+		httpClient := HttpClient{ServerAddress: "http://foo", Timeout: time.Second}
+		queue := httpClient.Subscribe("docType")
+		assert.Nil(t, queue)
+	})
+}

--- a/pkg/documentlog/impl.go
+++ b/pkg/documentlog/impl.go
@@ -75,6 +75,7 @@ func (dl *documentLog) Configure(store store.DocumentStore) {
 }
 
 func (dl *documentLog) Subscribe(documentType string) DocumentQueue {
+	log.Log().Infof("Creating subscription (document.type=%s)", documentType)
 	queue := documentQueue{
 		documentType: documentType,
 		c:            make(chan *model.Document, 100), // TODO: Does this number make sense?

--- a/pkg/documentlog/impl.go
+++ b/pkg/documentlog/impl.go
@@ -42,7 +42,7 @@ var ErrUnknownDocument = errors.New("unknown document")
 func NewDocumentLog(protocol proto.Protocol) DocumentLog {
 	documentLog := &documentLog{
 		protocol:            protocol,
-		subscriptions:       make(map[string]documentQueue, 0),
+		subscriptions:       make(map[string][]documentQueue, 0),
 		subscriptionsMutex:  concurrency.NewSaferRWMutex("doclog-subs"),
 		lastConsistencyHash: &atomic.Value{},
 	}
@@ -55,7 +55,7 @@ type documentLog struct {
 	protocol proto.Protocol
 	store    store.DocumentStore
 
-	subscriptions       map[string]documentQueue
+	subscriptions       map[string][]documentQueue
 	subscriptionsMutex  concurrency.SaferRWMutex
 	publicAddr          string
 	advertHashTimer     *time.Ticker
@@ -81,7 +81,11 @@ func (dl *documentLog) Subscribe(documentType string) DocumentQueue {
 		c:            make(chan *model.Document, 100), // TODO: Does this number make sense?
 	}
 	dl.subscriptionsMutex.WriteLock(func() {
-		dl.subscriptions[documentType] = queue
+		if subs, ok := dl.subscriptions[documentType]; ok {
+			dl.subscriptions[documentType] = append(subs, queue)
+		} else {
+			dl.subscriptions[documentType] = []documentQueue{queue}
+		}
 	})
 	return &queue
 }
@@ -165,9 +169,11 @@ func (dl *documentLog) AddDocumentContents(hash model.Hash, contents io.Reader) 
 		return nil, errors2.Wrap(err, "unable to write document contents")
 	}
 	dl.subscriptionsMutex.ReadLock(func() {
-		if queue, ok := dl.subscriptions[document.Type]; ok {
-			clone := document.Document.Clone()
-			queue.c <- &clone
+		if subs, ok := dl.subscriptions[document.Type]; ok {
+			for _, queue := range subs {
+				clone := document.Document.Clone()
+				queue.c <- &clone
+			}
 		}
 	})
 	return &document.Document, nil
@@ -180,7 +186,9 @@ func (dl *documentLog) Documents() ([]model.DocumentDescriptor, error) {
 func (dl *documentLog) Stop() {
 	dl.subscriptionsMutex.WriteLock(func() {
 		for _, sub := range dl.subscriptions {
-			close(sub.c)
+			for _, queue := range sub {
+				close(queue.c)
+			}
 		}
 	})
 	dl.advertHashTimer.Stop()

--- a/pkg/documentlog/impl_test.go
+++ b/pkg/documentlog/impl_test.go
@@ -188,6 +188,17 @@ func Test_DocumentLog_AddDocumentContents(t *testing.T) {
 	})
 }
 
+func Test_DocumentLog_Subscribe(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	t.Run("ok", func(t *testing.T) {
+		log := NewDocumentLog(proto.NewMockProtocol(mockCtrl)).(*documentLog)
+		queue := log.Subscribe("some-type")
+		assert.NotNil(t, queue)
+		assert.Len(t, log.subscriptions, 1)
+	})
+}
+
 func Test_DocumentLog_HasContents(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/documentlog/impl_test.go
+++ b/pkg/documentlog/impl_test.go
@@ -191,11 +191,35 @@ func Test_DocumentLog_AddDocumentContents(t *testing.T) {
 func Test_DocumentLog_Subscribe(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+	const docType = "some-type"
 	t.Run("ok", func(t *testing.T) {
 		log := NewDocumentLog(proto.NewMockProtocol(mockCtrl)).(*documentLog)
-		queue := log.Subscribe("some-type")
+		queue := log.Subscribe(docType)
 		assert.NotNil(t, queue)
 		assert.Len(t, log.subscriptions, 1)
+	})
+	t.Run("ok - multiple subscriptions", func(t *testing.T) {
+		log := NewDocumentLog(proto.NewMockProtocol(mockCtrl)).(*documentLog)
+		store := store.NewMockDocumentStore(mockCtrl)
+		store.EXPECT().Get(model.EmptyHash()).Return(&model.DocumentDescriptor{
+			Document:        model.Document{Type: docType},
+		}, nil)
+		store.EXPECT().WriteContents(model.EmptyHash(), gomock.Any())
+		log.Configure(store)
+		queue1 := log.Subscribe(docType)
+		assert.NotNil(t, queue1)
+		queue2 := log.Subscribe(docType)
+		assert.NotNil(t, queue2)
+		assert.Len(t, log.subscriptions, 1)
+		assert.Len(t, log.subscriptions[docType], 2)
+
+		// Now add documents to check whether both subscription receive the document
+		_, err := log.AddDocumentContents(model.EmptyHash(), bytes.NewReader([]byte{1, 2, 3}))
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Len(t, log.subscriptions[docType][0].c, 1)
+		assert.Len(t, log.subscriptions[docType][1].c, 1)
 	})
 }
 

--- a/pkg/documentlog/interface.go
+++ b/pkg/documentlog/interface.go
@@ -38,6 +38,7 @@ type DocumentLog interface {
 	Stop()
 }
 
+// Publisher is a PubSub interface for documents on the document log.
 type Publisher interface {
 	// Subscribe creates a subscription for incoming documents with the specified type. It can be read from using the
 	// returned DocumentQueue. There can be multiple subscribers for the same document type. The returned queue MUST

--- a/pkg/documentlog/interface.go
+++ b/pkg/documentlog/interface.go
@@ -27,6 +27,7 @@ import (
 
 // DocumentLog defines the API for the DocumentLog layer, used to store/retrieve chained documents.
 type DocumentLog interface {
+	Publisher
 	proto.HashSource
 	stats.StatsProvider
 	// Configure configures this DocumentLog. Must be called before Start().
@@ -35,6 +36,9 @@ type DocumentLog interface {
 	Start()
 	// Stops the document log.
 	Stop()
+}
+
+type Publisher interface {
 	// Subscribe creates a subscription for incoming documents with the specified type. It can be read from using the
 	// returned DocumentQueue. There can be multiple subscribers for the same document type. The returned queue MUST
 	// read from since it has an internal buffer which blocks the producer (the DocumentLog) when full.

--- a/pkg/interface.go
+++ b/pkg/interface.go
@@ -19,6 +19,7 @@
 package pkg
 
 import (
+	"github.com/nuts-foundation/nuts-network/pkg/documentlog"
 	"github.com/nuts-foundation/nuts-network/pkg/model"
 	"io"
 	"time"
@@ -26,6 +27,7 @@ import (
 
 // NetworkClient is the interface to be implemented by any remote or local client
 type NetworkClient interface {
+	documentlog.Publisher
 	// GetDocumentContents retrieves the document contents for the given hash. If the document of contents are not known, an error is returned.
 	GetDocumentContents(hash model.Hash) (io.ReadCloser, error)
 	// GetDocument retrieves the document for the given hash. If the document is not known, an error is returned.

--- a/pkg/mock.go
+++ b/pkg/mock.go
@@ -6,6 +6,7 @@ package pkg
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	documentlog "github.com/nuts-foundation/nuts-network/pkg/documentlog"
 	model "github.com/nuts-foundation/nuts-network/pkg/model"
 	io "io"
 	reflect "reflect"
@@ -33,6 +34,20 @@ func NewMockNetworkClient(ctrl *gomock.Controller) *MockNetworkClient {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockNetworkClient) EXPECT() *MockNetworkClientMockRecorder {
 	return m.recorder
+}
+
+// Subscribe mocks base method
+func (m *MockNetworkClient) Subscribe(documentType string) documentlog.DocumentQueue {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Subscribe", documentType)
+	ret0, _ := ret[0].(documentlog.DocumentQueue)
+	return ret0
+}
+
+// Subscribe indicates an expected call of Subscribe
+func (mr *MockNetworkClientMockRecorder) Subscribe(documentType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockNetworkClient)(nil).Subscribe), documentType)
 }
 
 // GetDocumentContents mocks base method

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -123,16 +123,16 @@ func (n *Network) Configure() error {
 		}
 		if n.Config.Mode == core.ServerEngineMode {
 			n.protocol.Configure(n.p2pNetwork, n.documentLog)
-			var documentStore store.DocumentStore
-			if documentStore, err = store.CreateDocumentStore(n.Config.StorageConnectionString); err != nil {
-				return
-			}
-			n.documentLog.Configure(documentStore)
 			identity := core.NutsConfig().VendorID()
 			if n.Config.NodeID == "" {
 				log.Log().Warnf("NodeID not configured, will use node identity: %s", identity)
 				n.Config.NodeID = identity.String()
 			}
+			var documentStore store.DocumentStore
+			if documentStore, err = store.CreateDocumentStore(n.Config.StorageConnectionString); err != nil {
+				return
+			}
+			n.documentLog.Configure(documentStore)
 			if err = n.nodeList.Configure(model.NodeID(n.Config.NodeID), n.Config.PublicAddr); err != nil {
 				err = errors2.Wrap(err, "unable to configure nodelist")
 				return
@@ -148,6 +148,10 @@ func (n *Network) Configure() error {
 		}
 	})
 	return err
+}
+
+func (n *Network) Subscribe(documentType string) documentlog.DocumentQueue {
+	return n.documentLog.Subscribe(documentType)
 }
 
 // Start initiates the network subsystem

--- a/pkg/network_test.go
+++ b/pkg/network_test.go
@@ -88,6 +88,16 @@ func TestNetwork_GetDocumentContents(t *testing.T) {
 	})
 }
 
+func TestNetwork_Subscribe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	t.Run("ok", func(t *testing.T) {
+		cxt := createNetwork(t, ctrl)
+		cxt.documentLog.EXPECT().Subscribe("some-type")
+		cxt.network.Subscribe("some-type")
+	})
+}
+
 func TestNetwork_Diagnostics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/p2p/impl.go
+++ b/pkg/p2p/impl.go
@@ -332,7 +332,7 @@ func (n p2pNetwork) shouldConnectTo(nodeInfo model.NodeInfo) bool {
 			for _, peer := range n.peers {
 				if peer.nodeID == nodeInfo.ID {
 					// We're not going to connect to a node we're already connected to
-					log.Log().Debugf("Not connecting since we're already connected (NodeID=%s)", nodeInfo.ID)
+					log.Log().Tracef("Not connecting since we're already connected (NodeID=%s)", nodeInfo.ID)
 					result = false
 					return
 				}
@@ -340,7 +340,7 @@ func (n p2pNetwork) shouldConnectTo(nodeInfo model.NodeInfo) bool {
 		}
 		if n.peersByAddr[normalizeAddress(nodeInfo.Address)] != nil {
 			// We're not going to connect to a node we're already connected to
-			log.Log().Debugf("Not connecting since we're already connected (address=%s)", nodeInfo.Address)
+			log.Log().Tracef("Not connecting since we're already connected (address=%s)", nodeInfo.Address)
 			result = false
 		}
 	})

--- a/pkg/test.go
+++ b/pkg/test.go
@@ -19,5 +19,6 @@ func NewTestNetworkInstance(testDirectory string) *Network {
 func TestNetworkConfig(testDirectory string) NetworkConfig {
 	config := DefaultNetworkConfig()
 	config.StorageConnectionString = "file:" + path.Join(testDirectory, "network.db")
+	config.PublicAddr = "test:5555"
 	return config
 }


### PR DESCRIPTION
Currently in-memory Go channels are backing the subscriptions, in the future this can/should be changed to a durable queue which survives restarts/crashes (e.g. Nats Streaming). Not a problem yet since the only subscriber is the registry which also gets it data (should it miss a received document due to a crash/error) through GitHub, but just a bit later.