### PR TITLE
Made NUTS_NETWORK_PUBLICADDR optional again

### DIFF
--- a/pkg/nodelist/impl.go
+++ b/pkg/nodelist/impl.go
@@ -45,9 +45,6 @@ func (n *nodeList) Configure(nodeID model.NodeID, address string) error {
 	if nodeID.Empty() {
 		return errors.New("nodeID is empty")
 	}
-	if address == "" {
-		return errors.New("address is empty")
-	}
 	n.localNode = model.NodeInfo{
 		ID:      nodeID,
 		Address: address,

--- a/pkg/nodelist/impl_test.go
+++ b/pkg/nodelist/impl_test.go
@@ -14,8 +14,8 @@ func Test_nodeList_Configure(t *testing.T) {
 		err := (&nodeList{}).Configure("", "foo:8080")
 		assert.EqualError(t, err, "nodeID is empty")
 	})
-	t.Run("error - address empty", func(t *testing.T) {
+	t.Run("ok - address empty", func(t *testing.T) {
 		err := (&nodeList{}).Configure("abc", "")
-		assert.EqualError(t, err, "address is empty")
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Used to be optional, got required somewhere in the process. Made it optional again, required some intelligent guessing regarding the listening address in the P2P layer to make sure we don't connect to our own node should node IDs change/be incorrect.