### PR TITLE
RFC004 Distributed Document implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,12 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/jinzhu/gorm v1.9.14
 	github.com/json-iterator/go v1.1.9 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/labstack/echo v3.3.10+incompatible // indirect
 	github.com/labstack/echo/v4 v4.1.17
+	github.com/lestrrat-go/jwx v1.0.5
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
-	github.com/nuts-foundation/nuts-crypto v0.15.0
+	github.com/nuts-foundation/nuts-crypto v0.15.1-0.20201015073554-cbeeb24605c8
 	github.com/nuts-foundation/nuts-go-core v0.15.0
 	github.com/nuts-foundation/nuts-go-test v0.15.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -290,10 +290,15 @@ github.com/labstack/echo/v4 v4.1.17 h1:PQIBaRplyRy3OjwILGkPg89JRtH2x5bssi59G2EL3
 github.com/labstack/echo/v4 v4.1.17/go.mod h1:Tn2yRQL/UclUalpb5rPdXDevbkJ+lp/2svdyFBg6CHQ=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/lestrrat-go/iter v0.0.0-20200422075355-fc1769541911 h1:FvnrqecqX4zT0wOIbYK1gNgTm0677INEWiFY8UEYggY=
+github.com/lestrrat-go/iter v0.0.0-20200422075355-fc1769541911/go.mod h1:zIdgO1mRKhn8l9vrZJZz9TUMMFbQbLeTsbqPDrJ/OJc=
 github.com/lestrrat-go/jwx v0.9.1 h1:yuDzdMCxjiY2oItdWPX3wM/blQ3kJrBmp3kcec7NNEE=
 github.com/lestrrat-go/jwx v0.9.1/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/lestrrat-go/jwx v0.9.2 h1:1neTPQvRiPRtQpU7QHEEG6dM8A1AFCgi1FGN/2VBucA=
 github.com/lestrrat-go/jwx v0.9.2/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
+github.com/lestrrat-go/jwx v1.0.5 h1:8bVUGXXkR3+YQNwuFof3lLxSJMLtrscHJfGI6ZIBRD0=
+github.com/lestrrat-go/jwx v1.0.5/go.mod h1:TPF17WiSFegZo+c20fdpw49QD+/7n4/IsGvEmCSWwT0=
+github.com/lestrrat-go/pdebug v0.0.0-20200204225717-4d6bd78da58d/go.mod h1:B06CSso/AWxiPejj+fheUINGeBKeeEZNt8w+EoU7+L8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -369,6 +374,8 @@ github.com/nuts-foundation/nuts-crypto v0.15.0 h1:C3E2NSXD1t3G1pPBOWtIr/V2r+y638
 github.com/nuts-foundation/nuts-crypto v0.15.0/go.mod h1:xz02sBTLi8w38xAGCpEV1jxhSd8r0/SviELIS3Ety0s=
 github.com/nuts-foundation/nuts-crypto v0.15.1-0.20200930071817-15a036b97663 h1:upPVJajmbK1xZoAFaVsKAoMUh1l4HJi8acWDCqFNU/E=
 github.com/nuts-foundation/nuts-crypto v0.15.1-0.20200930071817-15a036b97663/go.mod h1:d0W4unhrJVpeObzjOq5IV7RlhwKEC2fwY9yvE8JYnWQ=
+github.com/nuts-foundation/nuts-crypto v0.15.1-0.20201015073554-cbeeb24605c8 h1:RVtcvBk+IY6z6/vKmjCozef6C1kJob9KebEyCXkDpNs=
+github.com/nuts-foundation/nuts-crypto v0.15.1-0.20201015073554-cbeeb24605c8/go.mod h1:GnZN/7zk0DeTjKCakLuGjSjW34PUK//dog1L5TiqRIc=
 github.com/nuts-foundation/nuts-go-core v0.13.0/go.mod h1:YVG736ZUyC0nHRozNUsbLPRnxQouCzoARpswWgPV55g=
 github.com/nuts-foundation/nuts-go-core v0.13.1-0.20200422143012-856bc0bf2098/go.mod h1:UMfANk1YRb+7p5GFLexfHIVCXxgSOE+wLGU6gjR6uv4=
 github.com/nuts-foundation/nuts-go-core v0.13.1-0.20200422145233-a9d171e8b054 h1:ZNYy4xJgkNwBSk7nHzPsaEumQvV5wBSXNqk11NgQsko=
@@ -502,6 +509,7 @@ github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhe
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
@@ -698,6 +706,7 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200213224642-88e652f7a869/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200417140056-c07e33ef3290/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/documentlog/store/sql.go
+++ b/pkg/documentlog/store/sql.go
@@ -155,7 +155,7 @@ func (s sqlDocumentStore) updateConsistencyHashes(tx *gorm.DB, startPoint model.
 	for _, document := range documents {
 		hash, err := model.ParseHash(document.Hash)
 		if err != nil {
-			return consistencyHash, err
+			return model.EmptyHash(), err
 		}
 		consistencyHash = model.MakeConsistencyHash(consistencyHash, hash)
 		query := tx.Table(documentTable).Where("hash = ?", document.Hash).UpdateColumn("consistency_hash", consistencyHash.String())

--- a/pkg/documentlog/store/sql_integration_test.go
+++ b/pkg/documentlog/store/sql_integration_test.go
@@ -250,7 +250,7 @@ func Test_sqlDocumentStore_ReadContents(t *testing.T) {
 	docStore := new(sqlDocumentStore)
 	t.Run("error - document doesn't exist", func(t *testing.T) {
 		defer createDatabase(docStore)()
-		contents, err := docStore.ReadContents([]byte("1234"))
+		contents, err := docStore.ReadContents(model.SliceToHash([]byte{1, 2, 3}))
 		assert.Error(t, err)
 		assert.Nil(t, contents)
 	})

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -27,19 +27,18 @@ func TestDocument_Clone(t *testing.T) {
 			Timestamp: time.Now(),
 		}
 		actual := expected.Clone()
-		copy(expected.Hash, EmptyHash())
+		expected.Hash[0] = 0
 		assert.NotEqual(t, expected, actual)
 	})
-	t.Run("ok - nil hash", func(t *testing.T) {
-		expected := Document{
-			Hash:      nil,
+	t.Run("ok - change type", func(t *testing.T) {
+		unexpected := Document{
+			Hash:      EmptyHash(),
 			Type:      "foobar",
 			Timestamp: time.Now(),
 		}
-		actual := expected.Clone()
-		assert.Equal(t, expected, actual)
-		assert.NotSame(t, &expected, &actual)
-		assert.NotSame(t, expected.Hash, actual.Hash)
+		expected := unexpected.Clone()
+		expected.Type = "test"
+		assert.NotEqual(t, unexpected.Type, expected.Type)
 	})
 }
 
@@ -54,4 +53,97 @@ func TestMakeConsistencyHash(t *testing.T) {
 		actual := MakeConsistencyHash(EmptyHash(), expected)
 		assert.Equal(t, expected.String(), actual.String())
 	})
+}
+
+func TestHash_Empty(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.True(t, EmptyHash().Empty())
+	})
+	t.Run("non empty", func(t *testing.T) {
+		h, err := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.False(t, h.Empty())
+	})
+	t.Run("returns new hash every time", func(t *testing.T) {
+		h1 := EmptyHash()
+		h2 := EmptyHash()
+		assert.True(t, h1.Equals(h2))
+		h1[0] = 10
+		assert.False(t, h1.Equals(h2))
+	})
+}
+
+func TestHash_Slice(t *testing.T) {
+	t.Run("slice parsed hash", func(t *testing.T) {
+		h, err := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, h, SliceToHash(h.Slice()))
+	})
+	t.Run("returns new slice every time", func(t *testing.T) {
+		h, _ := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		s1 := h.Slice()
+		s2 := h.Slice()
+		assert.Equal(t, s1, s2)
+		s1[0] = 10
+		assert.NotEqual(t, s1, s2)
+	})
+}
+
+func TestParseHash(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		hash, err := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		assert.NoError(t, err)
+		assert.Equal(t, "383c9da631bd120169e82b0679e4c2e8d5050894", hash.String())
+	})
+	t.Run("ok - empty string input", func(t *testing.T) {
+		hash, err := ParseHash("")
+		assert.NoError(t, err)
+		assert.True(t, hash.Empty())
+	})
+	t.Run("error - invalid input", func(t *testing.T) {
+		hash, err := ParseHash("a23da")
+		assert.Error(t, err)
+		assert.True(t, hash.Empty())
+	})
+	t.Run("error - incorrect length", func(t *testing.T) {
+		hash, err := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894383c9da631bd120169e82b0679e4c2e8d5050894")
+		assert.EqualError(t, err, "incorrect hash length (40)")
+		assert.True(t, hash.Empty())
+	})
+}
+
+func TestHash_Equals(t *testing.T) {
+	t.Run("equal", func(t *testing.T) {
+		h1, _ := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		h2, _ := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		assert.True(t, h1.Equals(h2))
+	})
+	t.Run("not equal", func(t *testing.T) {
+		h1 := EmptyHash()
+		h2, _ := ParseHash("383c9da631bd120169e82b0679e4c2e8d5050894")
+		assert.False(t, h1.Equals(h2))
+	})
+}
+
+func TestHash_Compare(t *testing.T) {
+	t.Run("smaller", func(t *testing.T) {
+		h1, _ := ParseHash("0000000000000000000000000000000000000001")
+		h2, _ := ParseHash("0000000000000000000000000000000000000002")
+		assert.Equal(t, -1, h1.Compare(h2))
+	})
+	t.Run("equal", func(t *testing.T) {
+		h1, _ := ParseHash("0000000000000000000000000000000000000001")
+		h2, _ := ParseHash("0000000000000000000000000000000000000001")
+		assert.Equal(t, 0, h1.Compare(h2))
+	})
+	t.Run("larger", func(t *testing.T) {
+		h1, _ := ParseHash("0000000000000000000000000000000000000002")
+		h2, _ := ParseHash("0000000000000000000000000000000000000001")
+		assert.Equal(t, 1, h1.Compare(h2))
+	})
+
 }

--- a/pkg/nextgen/distdoc/document.go
+++ b/pkg/nextgen/distdoc/document.go
@@ -1,0 +1,203 @@
+package distdoc
+
+import (
+	"crypto"
+	"crypto/sha1"
+	"crypto/x509"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jws"
+	"github.com/lestrrat-go/jwx/jws/sign"
+	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
+	"github.com/nuts-foundation/nuts-network/pkg/model"
+	"github.com/pkg/errors"
+	"strings"
+	"time"
+)
+
+// Version defines a type for distributed document format version.
+type Version int
+
+const currentVersion = 1
+const signingTimeHeader = "sigt"
+const versionHeader = "ver"
+const previousHeader = "prevs"
+const timelineIDHeader = "tid"
+const timelineVersionHeader = "tiv"
+
+var allowedAlgos = []jwa.SignatureAlgorithm{jwa.ES256, jwa.ES384, jwa.ES512, jwa.PS256, jwa.PS384, jwa.PS512}
+
+var errInvalidPayloadType = errors.New("payload type must be formatted as MIME type")
+var errInvalidPrevs = errors.New("prevs contains an empty hash")
+var errSigningError = errors.New("error while signing document")
+var unableToParseDocumentErrFmt = "unable to parse document: %w"
+var documentNotValidErrFmt = "document validation failed: %w"
+var missingHeaderErrFmt = "missing %s header"
+var invalidHeaderErrFmt = "invalid %s header"
+
+// PayloadHash is a Hash of the payload of a Document
+type PayloadHash model.Hash
+
+// UnsignedDocument holds the base properties of a document which can be signed to create a Document.
+type UnsignedDocument interface {
+	// PayloadType returns the MIME-formatted type of the payload. It must contain the context and specific type of the
+	// payload, e.g. 'registry/endpoint'.
+	PayloadType() string
+	// Payload returns the hash of the payload of the document.
+	Payload() PayloadHash
+	// Previous returns the references of the previous documents this document points to.
+	Previous() []model.Hash
+	// Version returns the version number of the distributed document format.
+	Version() Version
+	// TimelineID returns the timeline ID of the document.
+	TimelineID() model.Hash
+	// TimelineVersion returns the timeline version of the document. If the returned version is < 1 the timeline version
+	// is not set.
+	TimelineVersion() int
+	// Sign signs the document using the given key and certificate. The certificate must correspond with the given
+	// signing key and must be meant (key usage) for signing. The moment parameter is included in the signature
+	// as time of signing.
+	Sign(key crypto.Signer, certificate *x509.Certificate, moment time.Time) (Document, error)
+}
+
+// Document defines a signed distributed document as described by RFC004 - Distributed Document Format.
+type Document interface {
+	UnsignedDocument
+	// SigningCertificate returns the certificate that was used for signing this document.
+	SigningCertificate() *x509.Certificate
+	// SigningTime returns the time that the document was signed.
+	SigningTime() time.Time
+	// Ref returns the reference to this document.
+	Ref() model.Hash
+	// Data returns the byte representation of this document which can be used for transport.
+	Data() []byte
+	// VerifySignature verifies that the signature are signing certificate are correct. If an error occurs or verification
+	// fails an error is returned.
+	VerifySignature(trustStore *x509.CertPool) error
+}
+
+// NewDocument creates a new unsigned document. Parameters payload and payloadType can't be empty, but prevs is optional.
+// Prevs must not contain empty or invalid hashes.
+func NewDocument(payload PayloadHash, payloadType string, prevs []model.Hash) (UnsignedDocument, error) {
+	if !ValidatePayloadType(payloadType) {
+		return nil, errInvalidPayloadType
+	}
+	for _, prev := range prevs {
+		if prev.Empty() {
+			return nil, errInvalidPrevs
+		}
+	}
+	return &document{
+		prevs:       append(prevs),
+		payload:     model.Hash(payload),
+		payloadType: payloadType,
+		version:     currentVersion,
+	}, nil
+}
+
+func ValidatePayloadType(payloadType string) bool {
+	return strings.Contains(payloadType, "/")
+}
+
+type document struct {
+	prevs           []model.Hash
+	payload         model.Hash
+	payloadType     string
+	certificate     *x509.Certificate
+	signingTime     time.Time
+	version         Version
+	timelineID      model.Hash
+	timelineVersion int
+
+	data []byte
+	ref  model.Hash
+}
+
+func (d document) Data() []byte {
+	return d.data
+}
+
+func (d document) SigningCertificate() *x509.Certificate {
+	return d.certificate
+}
+
+func (d document) SigningTime() time.Time {
+	return d.signingTime
+}
+
+func (d document) PayloadType() string {
+	return d.payloadType
+}
+
+func (d document) Payload() PayloadHash {
+	return PayloadHash(d.payload)
+}
+
+func (d document) Previous() []model.Hash {
+	return append(d.prevs)
+}
+
+func (d document) Ref() model.Hash {
+	return d.ref
+}
+
+func (d document) Version() Version {
+	return d.version
+}
+
+func (d document) TimelineID() model.Hash {
+	return d.timelineID
+}
+
+func (d document) TimelineVersion() int {
+	return d.timelineVersion
+}
+
+func (d document) VerifySignature(_ *x509.CertPool) error {
+	return errors.New("VerifySignature() not implemented yet!")
+}
+
+func (d *document) Sign(key crypto.Signer, certificate *x509.Certificate, moment time.Time) (Document, error) {
+	prevsAsString := make([]string, len(d.prevs))
+	for i, prev := range d.prevs {
+		prevsAsString[i] = prev.String()
+	}
+	// TODO: Make algorithm a parameter
+	algo := jwa.ES256
+	headerMap := map[string]interface{}{
+		jws.AlgorithmKey:     algo,
+		jws.ContentTypeKey:   d.payloadType,
+		jws.CriticalKey:      []string{signingTimeHeader, versionHeader, previousHeader},
+		jws.X509CertChainKey: cert.MarshalX509CertChain([]*x509.Certificate{certificate}),
+		signingTimeHeader:    moment.UTC().Unix(),
+		previousHeader:       prevsAsString,
+		versionHeader:        d.Version(),
+	}
+	if !d.timelineID.Empty() {
+		headerMap[timelineIDHeader] = d.timelineID
+		if d.timelineVersion > 0 {
+			headerMap[timelineVersionHeader] = d.timelineVersion
+		}
+	}
+	headers := jws.NewHeaders()
+	for key, value := range headerMap {
+		if err := headers.Set(key, value); err != nil {
+			return nil, errors.Wrapf(err, "unable to set header %s", key)
+		}
+	}
+	if signer, err := sign.New(algo); err != nil {
+		return nil, err
+	} else {
+		if data, err := jws.SignMulti([]byte(d.payload.String()), jws.WithSigner(signer, key, nil, headers)); err != nil {
+			return nil, errors.Wrap(err, errSigningError.Error())
+		} else {
+			d.setData(data)
+			d.certificate = certificate
+			return d, nil
+		}
+	}
+}
+
+func (d *document) setData(data []byte) {
+	d.data = data
+	d.ref = sha1.Sum(d.data)
+}

--- a/pkg/nextgen/distdoc/document_test.go
+++ b/pkg/nextgen/distdoc/document_test.go
@@ -1,0 +1,139 @@
+package distdoc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jws"
+	"github.com/nuts-foundation/nuts-crypto/test"
+	"github.com/nuts-foundation/nuts-network/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestNewDocument(t *testing.T) {
+	payloadHash, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0a")
+	payload := PayloadHash(payloadHash)
+	t.Run("ok", func(t *testing.T) {
+		hash, _ := model.ParseHash("31a3d460bb3c7d98845187c716a30db81c44b615")
+
+		document, err := NewDocument(payload, "some/type", []model.Hash{hash})
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, "some/type", document.PayloadType())
+		assert.Equal(t, document.Payload(), payload)
+		assert.Equal(t, []model.Hash{hash}, document.Previous())
+		assert.Equal(t, Version(1), document.Version())
+	})
+	t.Run("error - type empty", func(t *testing.T) {
+		document, err := NewDocument(payload, "", nil)
+		assert.EqualError(t, err, errInvalidPayloadType.Error())
+		assert.Nil(t, document)
+	})
+	t.Run("error - type not a MIME type", func(t *testing.T) {
+		document, err := NewDocument(payload, "foo", nil)
+		assert.EqualError(t, err, errInvalidPayloadType.Error())
+		assert.Nil(t, document)
+	})
+	t.Run("error - invalid prev", func(t *testing.T) {
+		document, err := NewDocument(payload, "foo/bar", []model.Hash{model.EmptyHash()})
+		assert.EqualError(t, err, errInvalidPrevs.Error())
+		assert.Nil(t, document)
+	})
+}
+
+func Test_document_Getters(t *testing.T) {
+	payload, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0a")
+	timelineID, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0b")
+	_, certificate := generateKeyAndCertificate()
+	prev1, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0a")
+	prev2, _ := model.ParseHash("b13098cdd24a364a0a6d16057473ad4d19d7dfb8")
+	doc := document{
+		prevs:           []model.Hash{prev1, prev2},
+		payload:         payload,
+		payloadType:     "foo/bar",
+		certificate:     certificate,
+		signingTime:     time.Unix(1023323333, 0),
+		version:         10,
+		timelineID:      timelineID,
+		timelineVersion: 10,
+	}
+	doc.setData([]byte{1, 2, 3})
+
+	assert.Equal(t, doc.prevs, doc.Previous())
+	assert.Equal(t, PayloadHash(doc.payload), doc.Payload())
+	assert.Equal(t, doc.payloadType, doc.PayloadType())
+	assert.Equal(t, doc.certificate, doc.SigningCertificate())
+	assert.Equal(t, doc.signingTime, doc.SigningTime())
+	assert.Equal(t, doc.version, doc.Version())
+	assert.Equal(t, doc.timelineID, doc.TimelineID())
+	assert.Equal(t, doc.timelineVersion, doc.TimelineVersion())
+	assert.Equal(t, doc.data, doc.Data())
+	assert.False(t, doc.Ref().Empty())
+}
+
+func Test_document_Sign(t *testing.T) {
+	payloadHash, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0a")
+	payload := PayloadHash(payloadHash)
+	key, certificate := generateKeyAndCertificate()
+	prev1, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0a")
+	prev2, _ := model.ParseHash("b13098cdd24a364a0a6d16057473ad4d19d7dfb8")
+	expectedPrevs := []model.Hash{prev1, prev2}
+	contentType := "foo/bar"
+	t.Run("ok", func(t *testing.T) {
+		doc, _ := NewDocument(payload, contentType, expectedPrevs)
+
+		signedDoc, err := doc.Sign(key, certificate, time.Date(2020, 10, 23, 13, 0, 0, 0, time.UTC))
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		t.Run("verify object properties", func(t *testing.T) {
+			assert.Equal(t, certificate.Raw, signedDoc.SigningCertificate().Raw)
+			assert.False(t, signedDoc.Ref().Empty())
+		})
+		t.Run("verify JWS", func(t *testing.T) {
+			message, _ := jws.ParseString(string(signedDoc.Data()))
+			assert.Len(t, message.Signatures(), 1, "expected 1 signature")
+			headers := message.Signatures()[0].ProtectedHeaders()
+			// JWS headers
+			assert.Equal(t, contentType, headers.ContentType())
+			assert.Equal(t, jwa.ES256, headers.Algorithm())
+			assert.Len(t, headers.X509CertChain(), 1)
+			// Custom headers
+			assert.Equal(t, int64(1603458000), int64(headers.PrivateParams()[signingTimeHeader].(float64)))
+			assert.Equal(t, 1, int(headers.PrivateParams()[versionHeader].(float64)))
+			prevs := headers.PrivateParams()[previousHeader]
+			assert.Len(t, prevs, 2, "expected 2 prevs")
+			assert.Equal(t, prev1.String(), prevs.([]interface{})[0].(string))
+			assert.Equal(t, prev2.String(), prevs.([]interface{})[1].(string))
+		})
+	})
+}
+
+func Test_document_VerifySignature(t *testing.T) {
+	t.Run("not implemented yet", func(t *testing.T) {
+		err := document{}.VerifySignature(nil)
+		assert.EqualError(t, err, "VerifySignature() not implemented yet!")
+	})
+}
+
+func generateKeyAndCertificate() (*ecdsa.PrivateKey, *x509.Certificate) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	certAsBytes := test.GenerateCertificateEx(time.Now(), key, 1, true, x509.KeyUsageContentCommitment)
+	certificate, _ := x509.ParseCertificate(certAsBytes)
+	return key, certificate
+}
+
+func generateRSAKeyAndCertificate() (*rsa.PrivateKey, *x509.Certificate) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+	certAsBytes := test.GenerateCertificateEx(time.Now(), key, 1, true, x509.KeyUsageContentCommitment)
+	certificate, _ := x509.ParseCertificate(certAsBytes)
+	return key, certificate
+}

--- a/pkg/nextgen/distdoc/dotviz_test.go
+++ b/pkg/nextgen/distdoc/dotviz_test.go
@@ -1,0 +1,72 @@
+package distdoc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DotGraphVisitor is a graph visitor that outputs the walked path as "dot" diagram.
+type DotGraphVisitor struct {
+	graph       *DAG
+	output      string
+	aliases     map[string]string
+	counter     int
+	labelStyle  LabelStyle
+	showAliases bool
+	showContent bool
+
+	nodes []string
+	edges []string
+}
+
+// LabelStyle defines node label styles for DotGraphVisitor.
+type LabelStyle int
+
+const (
+	// ShowAliasLabelStyle is a style that uses integer aliases for node labels.
+	ShowAliasLabelStyle LabelStyle = iota
+	// ShowAliasLabelStyle is a style that uses the references of nodes as label.
+	ShowRefLabelStyle LabelStyle = iota
+)
+
+func NewDotGraphVisitor(graph *DAG, labelStyle LabelStyle) *DotGraphVisitor {
+	return &DotGraphVisitor{
+		graph:      graph,
+		aliases:    map[string]string{},
+		labelStyle: labelStyle,
+	}
+}
+
+func (d *DotGraphVisitor) Accept(document Document) {
+	d.counter++
+	d.nodes = append(d.nodes, fmt.Sprintf("  \"%s\"[label=\"%s (%d)\"]", document.Ref().String(), d.label(document), d.counter))
+	for _, prev := range document.Previous() {
+		d.edges = append(d.edges, fmt.Sprintf("  \"%s\" -> \"%s\"", prev.String(), document.Ref().String()))
+	}
+}
+
+func (d *DotGraphVisitor) Render() string {
+	var lines []string
+	lines = append(lines, "digraph {")
+	lines = append(lines, d.nodes...)
+	lines = append(lines, d.edges...)
+	lines = append(lines, "}")
+	return strings.Join(lines, "\n")
+}
+
+func (d *DotGraphVisitor) label(document Document) string {
+	switch d.labelStyle {
+	case ShowAliasLabelStyle:
+		if alias, ok := d.aliases[document.Ref().String()]; ok {
+			return alias
+		} else {
+			alias = fmt.Sprintf("%d", len(d.aliases)+1)
+			d.aliases[document.Ref().String()] = alias
+			return alias
+		}
+	case ShowRefLabelStyle:
+		fallthrough
+	default:
+		return document.Ref().String()
+	}
+}

--- a/pkg/nextgen/distdoc/graph.go
+++ b/pkg/nextgen/distdoc/graph.go
@@ -1,0 +1,163 @@
+package distdoc
+
+import (
+	"container/list"
+	"errors"
+	"github.com/nuts-foundation/nuts-network/pkg/model"
+	"sort"
+)
+
+var errRootAlreadyExists = errors.New("root document already exists")
+
+// DAG is a directed acyclic graph consisting of nodes (documents) referring to preceding nodes.
+type DAG struct {
+	// root contains the root node of the DAG
+	root  *node
+	nodes map[model.Hash]*node
+	// missingEdges contains the forward references (A -> [B, C]) which couldn't be updated since documents were added out-of-order (B and C were added before A).
+	missingEdges map[model.Hash][]*node
+}
+
+type node struct {
+	document Document
+	// edges contains forward references between documents (A -> B) so we can walk the DAG top to bottom more easily.
+	// This is the inverse of the 'prevs' field which a backreference (B -> A).
+	edges map[model.Hash]*node
+}
+
+// Visitor defines the contract for a function that visits the DAG.
+type Visitor func(document Document)
+
+func NewDAG() *DAG {
+	return &DAG{
+		nodes:        map[model.Hash]*node{},
+		missingEdges: map[model.Hash][]*node{},
+	}
+}
+
+// MissingDocuments returns the hashes of the documents we know we are missing and should still be resolved.
+func (c DAG) MissingDocuments() []model.Hash {
+	result := make([]model.Hash, 0, len(c.missingEdges))
+	for hash, _ := range c.missingEdges {
+		result = append(result, hash.Clone())
+	}
+	return result
+}
+
+// Add adds one or more documents to the DAG. If it can't be added an error is returned. Nil entries are ignored.
+func (c *DAG) Add(documents ...Document) error {
+	for _, document := range documents {
+		if document != nil {
+			if err := c.add(document); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *DAG) add(document Document) error {
+	// TODO: Check cyclic -> error
+	ref := document.Ref()
+	if _, ok := c.nodes[ref]; ok {
+		// We already have this node
+		return nil
+	}
+	newEntry := node{
+		document: document,
+		edges:    map[model.Hash]*node{},
+	}
+	// Check if this is a root document
+	if len(document.Previous()) == 0 {
+		if c.root == nil {
+			c.root = &newEntry
+		} else {
+			return errRootAlreadyExists
+		}
+	}
+	// Make sure nodes' edges field is kept up to date with a pointer to the new document (A -> B)
+	for _, prev := range document.Previous() {
+		if prevEntry, ok := c.nodes[prev]; ok {
+			prevEntry.edges[ref] = &newEntry
+		} else {
+			// We don't have this previous document yet, mark it as a missing edge so we can quickly update the A -> B
+			// edge when we receive B. This is the case when documents are added out-of-order.
+			missingEdges := c.missingEdges[prev]
+			c.missingEdges[prev] = append(missingEdges, &newEntry)
+		}
+	}
+	// Update forward references (A -> B) for documents that refer to this document but were added earlier (out-of-order)
+	missingEdges := c.missingEdges[ref]
+	if len(missingEdges) > 0 {
+		for _, nextNode := range missingEdges {
+			newEntry.edges[nextNode.document.Ref()] = nextNode
+		}
+		delete(c.missingEdges, ref)
+	}
+	c.nodes[ref] = &newEntry
+	return nil
+}
+
+// Walk visits every node of the DAG, starting at the root node and working down each level until every leaf is visited.
+func (c DAG) Walk(visitor Visitor) {
+	if c.root == nil {
+		return
+	}
+	// The algorithm below is a Breadth-First-Search (BFS) as described by Anany Levitin in "The Design & Analysis of Algorithms".
+	// It visits the whole tree level for level (breadth first vs depth first). It works by taking a node from queue and
+	// then adds the node's children (downward edges) to the queue. It starts by adding the root node to the queue and
+	// loops over the queue until empty, meaning all nodes reachable from the root node have been visited. Since our
+	// DAG contains merges (two parents referring to the same child node) we also keep a map to avoid visiting a
+	// merger node twice.
+	//
+	// This also means we have to make sure we don't visit the merger node before all of its previous nodes have been
+	// visited, which BFS doesn't account for. If that happens we skip the node without marking it as visited,
+	// so it will be visited again when the unvisited previous node is visited, which re-adds the merger node to the queue.
+	queue := list.New()
+	queue.PushBack(c.root)
+	visitedNodes := make(map[*node]bool, len(c.nodes))
+	visitedDocuments := make(map[model.Hash]bool, len(c.nodes))
+ProcessQueueLoop:
+	for queue.Len() > 0 {
+		// Pop first element of queue
+		front := queue.Front()
+		queue.Remove(front)
+		currentNode := front.Value.(*node)
+
+		// Make sure we haven't already visited this node
+		if _, visited := visitedNodes[currentNode]; visited {
+			continue
+		}
+
+		// Make sure all prevs have been visited. Otherwise just continue, it will be re-added to the queue when the
+		// unvisited prev node is visited and re-adds this node to the processing queue.
+		for _, prev := range currentNode.document.Previous() {
+			if _, visited := visitedDocuments[prev]; !visited {
+				continue ProcessQueueLoop
+			}
+		}
+
+		// Add child nodes to processing queue
+		// Processing order of nodes on the same level doesn't really matter for correctness of the DAG travel
+		// but it makes testing easier.
+		if currentNode.edges != nil {
+			sortedEdges := make([]*node, 0, len(currentNode.edges))
+			for _, nextNode := range currentNode.edges {
+				sortedEdges = append(sortedEdges, nextNode)
+			}
+			sort.Slice(sortedEdges, func(i, j int) bool {
+				return sortedEdges[i].document.Ref().Compare(sortedEdges[j].document.Ref()) < 0
+			})
+			for _, nextNode := range sortedEdges {
+				queue.PushBack(nextNode)
+			}
+		}
+
+		// Visit the node
+		visitor(currentNode.document)
+
+		// Mark this node as visited
+		visitedNodes[currentNode] = true
+		visitedDocuments[currentNode.document.Ref()] = true
+	}
+}

--- a/pkg/nextgen/distdoc/graph_test.go
+++ b/pkg/nextgen/distdoc/graph_test.go
@@ -1,0 +1,216 @@
+package distdoc
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/binary"
+	"github.com/nuts-foundation/nuts-network/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+// trackingVisitor just keeps track of which nodes were visited in what order.
+type trackingVisitor struct {
+	documents []Document
+}
+
+func (n *trackingVisitor) Accept(document Document) {
+	n.documents = append(n.documents, document)
+}
+
+func (n trackingVisitor) JoinRefsAsString() string {
+	var contents []string
+	for _, document := range n.documents {
+		val := strings.TrimLeft(document.Ref().String(), "0")
+		if val == "" {
+			val = "0"
+		}
+		contents = append(contents, val)
+	}
+	return strings.Join(contents, ", ")
+}
+
+func TestChain_Add(t *testing.T) {
+	key, certificate := generateKeyAndCertificate()
+	t.Run("ok", func(t *testing.T) {
+		graph := NewDAG()
+		doc := testDocument(0)
+
+		err := graph.Add(doc)
+
+		assert.NoError(t, err)
+		visitor := trackingVisitor{}
+		graph.Walk(visitor.Accept)
+		assert.Len(t, visitor.documents, 1)
+		assert.Equal(t, doc.Ref(), visitor.documents[0].Ref())
+	})
+	t.Run("ok - out of order", func(t *testing.T) {
+		_, documents := graphF(key, certificate)
+		graph := NewDAG()
+
+		for i := len(documents) - 1; i >= 0; i-- {
+			graph.Add(documents[i])
+		}
+
+		visitor := trackingVisitor{}
+		graph.Walk(visitor.Accept)
+		assert.Equal(t, "0, 1, 2, 3, 4, 5", visitor.JoinRefsAsString())
+	})
+	t.Run("error - cyclic graph", func(t *testing.T) {
+		t.Skip("Algorithm for detecting cycles is not yet decided on")
+		// A -> B -> C -> B
+		A := testDocument(0)
+		B := testDocument(1, A.Ref()).(*document)
+		C := testDocument(2, B.Ref())
+		B.prevs = append(B.prevs, C.Ref())
+
+		graph := NewDAG()
+		err := graph.Add(A, B, C)
+		assert.EqualError(t, err, "")
+	})
+}
+
+func TestChain_Walk(t *testing.T) {
+	key, certificate := generateKeyAndCertificate()
+
+	t.Run("ok - walk graph F", func(t *testing.T) {
+		visitor := trackingVisitor{}
+		graph, _ := graphF(key, certificate)
+
+		graph.Walk(visitor.Accept)
+
+		assert.Equal(t, "0, 1, 2, 3, 4, 5", visitor.JoinRefsAsString())
+	})
+
+	t.Run("ok - walk graph G", func(t *testing.T) {
+		//..................A
+		//................/  \
+		//...............B    C
+		//...............\   / \
+		//.................D    E
+		//.................\.....\
+		//..................\.....F
+		//...................\.../
+		//.....................G
+		visitor := trackingVisitor{}
+		graph, docs := graphF(key, certificate)
+		G := testDocument(6, docs[3].Ref(), docs[5].Ref())
+		graph.Add(G)
+
+		graph.Walk(visitor.Accept)
+
+		assert.Equal(t, "0, 1, 2, 3, 4, 5, 6", visitor.JoinRefsAsString())
+	})
+
+	t.Run("ok - walk graph F, C is missing", func(t *testing.T) {
+		//..................A
+		//................/  \
+		//...............B    C (missing)
+		//...............\   / \
+		//.................D    E
+		//.......................\
+		//........................F
+		visitor := trackingVisitor{}
+		_, docs := graphF(key, certificate)
+		graph := NewDAG()
+		graph.Add(docs[0], docs[1], docs[3], docs[4], docs[5])
+
+		graph.Walk(visitor.Accept)
+
+		assert.Equal(t, "0, 1", visitor.JoinRefsAsString())
+	})
+
+	t.Run("ok - empty graph", func(t *testing.T) {
+		graph := NewDAG()
+		visitor := trackingVisitor{}
+
+		graph.Walk(visitor.Accept)
+
+		assert.Empty(t, visitor.documents)
+	})
+
+	t.Run("ok - document added twice", func(t *testing.T) {
+		graph := NewDAG()
+		d := testDocument(0)
+		graph.Add(d)
+		err := graph.Add(d)
+		assert.NoError(t, err)
+		visitor := trackingVisitor{}
+
+		graph.Walk(visitor.Accept)
+
+		assert.Len(t, visitor.documents, 1)
+	})
+
+	t.Run("error - second root document", func(t *testing.T) {
+		graph := NewDAG()
+		d1 := testDocument(0 )
+		d2 := testDocument(1)
+		graph.Add(d1)
+		err := graph.Add(d2)
+		assert.Equal(t, errRootAlreadyExists, err)
+		visitor := trackingVisitor{}
+
+		graph.Walk(visitor.Accept)
+
+		assert.Len(t, visitor.documents, 1)
+		assert.Equal(t, d1, visitor.documents[0])
+	})
+}
+
+
+func TestDAG_MissingDocuments(t *testing.T) {
+	A := testDocument(0)
+	B := testDocument(1, A.Ref())
+	C := testDocument(2, B.Ref())
+	t.Run("no missing documents (empty graph)", func(t *testing.T) {
+		graph := NewDAG()
+		assert.Empty(t, graph.MissingDocuments())
+	})
+	t.Run("no missing documents (non-empty graph)", func(t *testing.T) {
+		graph := NewDAG()
+		graph.Add(A, B, C)
+		assert.Empty(t, graph.MissingDocuments())
+	})
+	t.Run("missing documents (non-empty graph)", func(t *testing.T) {
+		graph := NewDAG()
+		graph.Add(A, C)
+		assert.Len(t, graph.MissingDocuments(), 1)
+		// Now add missing document B and assert there are no more missing documents
+		graph.Add(B)
+		assert.Empty(t, graph.MissingDocuments())
+	})
+}
+
+// graphF creates the following graph:
+//..................A
+//................/  \
+//...............B    C
+//...............\   / \
+//.................D    E
+//.......................\
+//........................F
+func graphF(key crypto.Signer, certificate *x509.Certificate) (*DAG, []Document) {
+	graph := NewDAG()
+	A := testDocument(0)
+	B := testDocument(1, A.Ref())
+	C := testDocument(2, A.Ref())
+	D := testDocument(3, B.Ref(), C.Ref())
+	E := testDocument(4, C.Ref())
+	F := testDocument(5, E.Ref())
+	docs := []Document{A, B, C, D, E, F}
+	graph.Add(docs...)
+	return graph, docs
+}
+
+func testDocument(num uint32, prevs ...model.Hash) Document {
+	ref := model.EmptyHash()
+	binary.BigEndian.PutUint32(ref[model.HashSize-4:], num)
+	return &document{
+		prevs:       prevs,
+		payload:     ref,
+		payloadType: "foo/bar",
+		ref:         ref,
+	}
+}

--- a/pkg/nextgen/distdoc/parser.go
+++ b/pkg/nextgen/distdoc/parser.go
@@ -1,0 +1,184 @@
+package distdoc
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jws"
+	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
+	"github.com/nuts-foundation/nuts-network/pkg/model"
+	"time"
+)
+
+func ParseDocument(input []byte) (Document, error) {
+	message, err := jws.Parse(bytes.NewReader(input))
+	if err != nil {
+		return nil, fmt.Errorf(unableToParseDocumentErrFmt, err)
+	}
+	if len(message.Signatures()) == 0 {
+		return nil, documentValidationError("JWS does not contain any signature")
+	}
+	signature := message.Signatures()[0]
+	headers := signature.ProtectedHeaders()
+
+	var steps = []documentParseStep{
+		parseSigningAlgorithm,
+		parsePayload,
+		parseContentType,
+		parseX509CertChain,
+		parseSigningTime,
+		parseVersion,
+		parsePrevious,
+		parseTimelineID,
+		parseTimelineVersion,
+	}
+
+	result := &document{}
+	result.setData(input)
+	for _, step := range steps {
+		if err := step(result, headers, message); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func documentValidationError(format string, args ...interface{}) error {
+	return fmt.Errorf(documentNotValidErrFmt, fmt.Errorf(format, args...))
+}
+
+// documentParseStep defines a function that parses a part of a JWS, building the internal representation of a document.
+// If an error occurs during parsing or validation it should be returned.
+type documentParseStep func(document *document, headers jws.Headers, message *jws.Message) error
+
+// parseSigningAlgorithm validates whether the signing algorithm is allowed
+func parseSigningAlgorithm(_ *document, headers jws.Headers, _ *jws.Message) error {
+	if !isAlgoAllowed(headers.Algorithm()) {
+		return documentValidationError("signing algorithm not allowed: %s", headers.Algorithm())
+	}
+	return nil
+}
+
+// parsePayload parses the document payload (contents) and sets it
+func parsePayload(document *document, _ jws.Headers, message *jws.Message) error {
+	if payload, err := model.ParseHash(string(message.Payload())); err != nil {
+		return documentValidationError("invalid payload: %w", err)
+	} else {
+		document.payload = payload
+		return nil
+	}
+}
+
+// parseContentType parses, validates and sets the document payload content type.
+func parseContentType(document *document, headers jws.Headers, _ *jws.Message) error {
+	contentType := headers.ContentType()
+	if !ValidatePayloadType(contentType) {
+		return documentValidationError(errInvalidPayloadType.Error())
+	} else {
+		document.payloadType = contentType
+		return nil
+	}
+}
+
+// parseX509CertChain parses, validates and sets the certificate that was used for signing the JWS.
+func parseX509CertChain(document *document, headers jws.Headers, _ *jws.Message) error {
+	if certificates, err := cert.GetX509ChainFromHeaders(headers); err != nil {
+		return documentValidationError("invalid %s header: %w", jws.X509CertChainKey, err)
+	} else if len(certificates) != 1 {
+		return documentValidationError("expected 1 certificate in %s header", jws.X509CertChainKey)
+	} else {
+		document.certificate = certificates[0]
+		return nil
+	}
+}
+
+// parseSigningTime parses, validates and sets the document signing time.
+func parseSigningTime(document *document, headers jws.Headers, _ *jws.Message) error {
+	if timeAsInterf, ok := headers.Get(signingTimeHeader); !ok {
+		return documentValidationError(missingHeaderErrFmt, signingTimeHeader)
+	} else if timeAsFloat64, ok := timeAsInterf.(float64); !ok {
+		return documentValidationError(invalidHeaderErrFmt, signingTimeHeader)
+	} else {
+		document.signingTime = time.Unix(int64(timeAsFloat64), 0)
+		return nil
+	}
+}
+
+// parseVersion parses, validates and sets the document format version.
+func parseVersion(document *document, headers jws.Headers, _ *jws.Message) error {
+	var version Version
+	if versionAsInterf, ok := headers.Get(versionHeader); !ok {
+		return documentValidationError(missingHeaderErrFmt, versionHeader)
+	} else if versionAsFloat64, ok := versionAsInterf.(float64); !ok {
+		return documentValidationError(invalidHeaderErrFmt, versionHeader)
+	} else if version = Version(versionAsFloat64); version != currentVersion {
+		return documentValidationError("unsupported version: %d", version)
+	} else {
+		document.version = version
+		return nil
+	}
+}
+
+// parsePrevious parses, validates and sets the document prevs fields.
+func parsePrevious(document *document, headers jws.Headers, _ *jws.Message) error {
+	if prevsAsInterf, ok := headers.Get(previousHeader); !ok {
+		return documentValidationError(missingHeaderErrFmt, previousHeader)
+	} else if prevsAsSlice, ok := prevsAsInterf.([]interface{}); !ok {
+		return documentValidationError(invalidHeaderErrFmt, previousHeader)
+	} else {
+		for _, prevAsInterf := range prevsAsSlice {
+			if prevAsString, ok := prevAsInterf.(string); !ok {
+				return documentValidationError(invalidHeaderErrFmt, previousHeader)
+			} else if prev, err := model.ParseHash(prevAsString); err != nil {
+				return documentValidationError(invalidHeaderErrFmt, previousHeader)
+			} else {
+				document.prevs = append(document.prevs, prev)
+			}
+		}
+		return nil
+	}
+}
+
+// parseTimelineID parses, validates and sets the document timeline ID field.
+func parseTimelineID(document *document, headers jws.Headers, _ *jws.Message) error {
+	if tidAsInterf, _ := headers.Get(timelineIDHeader); tidAsInterf != nil {
+		if tidAsString, ok := tidAsInterf.(string); !ok {
+			return documentValidationError(invalidHeaderErrFmt, timelineIDHeader)
+		} else if timelineID, err := model.ParseHash(tidAsString); err != nil {
+			return documentValidationError(invalidHeaderErrFmt+": %w", timelineIDHeader, err)
+		} else {
+			document.timelineID = timelineID
+		}
+	}
+	return nil
+}
+
+// parseTimelineVersion parses, validates and sets the document timeline version field. Timeline ID must be present when
+// timeline version is present.
+func parseTimelineVersion(document *document, headers jws.Headers, _ *jws.Message) error {
+	tivAsInterf, _ := headers.Get(timelineVersionHeader)
+	if tivAsInterf == nil {
+		return nil
+	}
+	if tiv, ok := tivAsInterf.(float64); !ok {
+		return documentValidationError(invalidHeaderErrFmt, timelineVersionHeader)
+	} else if tiv < 0 {
+		return documentValidationError(invalidHeaderErrFmt, timelineVersionHeader)
+	} else if document.timelineID.Empty() {
+		return documentValidationError("%s specified without %s header", timelineVersionHeader, timelineIDHeader)
+	} else if tiv != float64(int(tiv)) {
+		return documentValidationError(invalidHeaderErrFmt, timelineVersionHeader)
+	} else {
+		document.timelineVersion = int(tiv)
+		return nil
+	}
+}
+
+func isAlgoAllowed(algo jwa.SignatureAlgorithm) bool {
+	for _, current := range allowedAlgos {
+		if algo == current {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/nextgen/distdoc/parser_test.go
+++ b/pkg/nextgen/distdoc/parser_test.go
@@ -1,0 +1,314 @@
+package distdoc
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jws"
+	"github.com/nuts-foundation/nuts-crypto/pkg/cert"
+	"github.com/nuts-foundation/nuts-network/pkg/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestParseDocument(t *testing.T) {
+	key, certificate := generateKeyAndCertificate()
+	payload, _ := model.ParseHash("f33b5cae968cb88f157999b3551ab0863d2a8f0a")
+	payloadAsBytes := []byte(payload.String())
+	t.Run("ok", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.NotNil(t, document)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, PayloadHash(payload), document.Payload())
+		assert.Equal(t, certificate.Raw, document.SigningCertificate().Raw)
+		assert.Equal(t, 1, int(document.Version()))
+		assert.Equal(t, "foo/bar", document.PayloadType())
+		assert.Equal(t, headers.PrivateParams()[previousHeader].([]string)[0], document.Previous()[0].String())
+		assert.Equal(t, headers.PrivateParams()[timelineIDHeader].(string), document.TimelineID().String())
+		assert.Equal(t, headers.PrivateParams()[timelineVersionHeader].(int), document.TimelineVersion())
+		assert.NotNil(t, document.Data())
+		assert.False(t, document.Ref().Empty())
+	})
+	t.Run("error - input not a JWS (compact serialization format)", func(t *testing.T) {
+		document, err := ParseDocument([]byte("not a JWS"))
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "unable to parse document: failed to parse jws message: invalid compact serialization format")
+	})
+	t.Run("error - input not a JWS (JSON serialization format)", func(t *testing.T) {
+		document, err := ParseDocument([]byte("{}"))
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: JWS does not contain any signature")
+	})
+	t.Run("error - sigt header is missing", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		delete(headers.PrivateParams(), signingTimeHeader)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: missing sigt header")
+	})
+	t.Run("error - invalid sigt header", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(signingTimeHeader, "not a date")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: invalid sigt header")
+	})
+	t.Run("error - vers header is missing", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		delete(headers.PrivateParams(), versionHeader)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: missing ver header")
+	})
+	t.Run("error - prevs header is missing", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		delete(headers.PrivateParams(), previousHeader)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: missing prevs header")
+	})
+	t.Run("error - invalid prevs (not an array)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(previousHeader, 2)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: invalid prevs header")
+	})
+	t.Run("error - invalid prevs (invalid entry)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(previousHeader, []string{"not a hash"})
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: invalid prevs header")
+	})
+	t.Run("error - invalid prevs (invalid entry, not a string)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(previousHeader, []int{5})
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: invalid prevs header")
+	})
+	t.Run("error - cty header is invalid", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(jws.ContentTypeKey, "")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: payload type must be formatted as MIME type")
+	})
+	t.Run("error - invalid version", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(versionHeader, "foobar")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: invalid ver header")
+	})
+	t.Run("error - unsupported version", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(versionHeader, 2)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: unsupported version: 2")
+	})
+	t.Run("error - invalid algorithm", func(t *testing.T) {
+		key, certificate := generateRSAKeyAndCertificate()
+		headers := makeJWSHeaders(certificate)
+		headers.Set(jws.AlgorithmKey, jwa.RS256)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: signing algorithm not allowed: RS256")
+	})
+	t.Run("error - invalid x5c header (too many entries)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(jws.X509CertChainKey, []string{base64.StdEncoding.EncodeToString(certificate.Raw), base64.StdEncoding.EncodeToString(certificate.Raw)})
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: expected 1 certificate in x5c header")
+	})
+	t.Run("error - invalid x5c header (not a certificate)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(jws.X509CertChainKey, []string{base64.StdEncoding.EncodeToString([]byte{1, 2, 3})})
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid x5c header")
+	})
+	t.Run("error - no certificates in x5c header", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(jws.X509CertChainKey, []string{})
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.EqualError(t, err, "document validation failed: expected 1 certificate in x5c header")
+	})
+	t.Run("error - invalid tid header", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(timelineIDHeader, "not a valid hash")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid tid header")
+	})
+	t.Run("error - invalid tid header (not a string)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(timelineIDHeader, 5)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid tid header")
+	})
+	t.Run("error - invalid tiv header (not a numeric value)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(timelineVersionHeader, "not a numeric value")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid tiv header")
+	})
+	t.Run("error - invalid tiv header (not a numeric value)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(timelineVersionHeader, "not a numeric value")
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid tiv header")
+	})
+	t.Run("error - invalid tiv header (value smaller than 0)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(timelineVersionHeader, -1)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid tiv header")
+	})
+	t.Run("error - invalid tiv header (value non-integer)", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		headers.Set(timelineVersionHeader, 1.5)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid tiv header")
+	})
+	t.Run("error - tiv header without tid", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		delete(headers.PrivateParams(), timelineIDHeader)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: tiv specified without tid header")
+	})
+	t.Run("error - tiv header without tid", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		delete(headers.PrivateParams(), timelineIDHeader)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: tiv specified without tid header")
+	})
+	t.Run("error - invalid payload", func(t *testing.T) {
+		headers := makeJWSHeaders(certificate)
+		signature, _ := jws.Sign([]byte("not a valid hash"), headers.Algorithm(), key, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid payload")
+	})
+	t.Run("error - certificate does not match key", func(t *testing.T) {
+		t.SkipNow()
+		otherKey, _ := generateKeyAndCertificate()
+		headers := makeJWSHeaders(certificate)
+		signature, _ := jws.Sign(payloadAsBytes, headers.Algorithm(), otherKey, jws.WithHeaders(headers))
+
+		document, err := ParseDocument(signature)
+
+		assert.Nil(t, document)
+		assert.Contains(t, err.Error(), "document validation failed: invalid payload")
+	})
+}
+
+func makeJWSHeaders(certificate *x509.Certificate) jws.Headers {
+	prev, _ := model.ParseHash("4d7a93b838bb1f2176d9daa9574c887313e36620")
+	timelineID, _ := model.ParseHash("0e5f927353a9b0b79c27fec27fb32c07c98f411c")
+	headerMap := map[string]interface{}{
+		jws.AlgorithmKey:      jwa.ES256,
+		jws.ContentTypeKey:    "foo/bar",
+		jws.CriticalKey:       []string{signingTimeHeader, versionHeader, previousHeader},
+		jws.X509CertChainKey:  cert.MarshalX509CertChain([]*x509.Certificate{certificate}),
+		signingTimeHeader:     time.Now().UTC().Unix(),
+		versionHeader:         1,
+		previousHeader:        []string{prev.String()},
+		timelineIDHeader:      timelineID.String(),
+		timelineVersionHeader: 1,
+	}
+	headers := jws.NewHeaders()
+	for key, value := range headerMap {
+		if err := headers.Set(key, value); err != nil {
+			logrus.Fatalf("Unable to set header %s: %v", key, err)
+		}
+	}
+	return headers
+}

--- a/pkg/proto/impl.go
+++ b/pkg/proto/impl.go
@@ -80,7 +80,7 @@ func (p protocol) ReceivedConsistencyHashes() PeerHashQueue {
 
 func (p protocol) AdvertConsistencyHash(hash model.Hash) {
 	msg := createMessage()
-	msg.AdvertHash = &network.AdvertHash{Hash: hash}
+	msg.AdvertHash = &network.AdvertHash{Hash: hash.Slice()}
 	p.p2pNetwork.Broadcast(&msg)
 }
 

--- a/pkg/proto/stats_test.go
+++ b/pkg/proto/stats_test.go
@@ -27,6 +27,6 @@ import (
 
 func TestPeerConsistencyHashStatistic(t *testing.T) {
 	diagnostic := peerConsistencyHashStatistic{peerHashes: new(map[model.PeerID]model.Hash), mux: &sync.Mutex{}}
-	diagnostic.copyFrom(map[model.PeerID]model.Hash{"abc": []byte{1, 2, 3}})
-	assert.Equal(t, diagnostic.String(), "010203={abc}")
+	diagnostic.copyFrom(map[model.PeerID]model.Hash{"abc": model.SliceToHash([]byte{1, 2, 3})})
+	assert.Equal(t, diagnostic.String(), "0102030000000000000000000000000000000000={abc}")
 }


### PR DESCRIPTION
Fixes #42 

TODO:

- [x] Validation of added documents
- [x] Parsing documents
- [ ] Detecting cycles

Thoughts:

- [x] Since the document payload is embedded in the JWS, the chain can only be validated when the document including payload is present. Since payload may be large, this could pose problems when wanting to quickly revalidate the DAG (since large files have to be read from disk and hashed). Possible solution: make the signature just include a hash of the payload: the document just contains the JWS signature without the payload itself. In other words, it is 'detached'. Then the chain can be verified without having to hash all contents (which might be large) or without even having all contents.

After discussion: we'll detach the content, so payload will be SHA-1 hash of contents.