### PR TITLE
Fix zero timestamp <> unix nanoseconds conversion, ignore invalid documents

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 )
 
 // ApiWrapper is needed to connect the implementation to the echo ServiceWrapper
@@ -90,7 +89,7 @@ func (a ApiWrapper) AddDocument(ctx echo.Context) error {
 		logging.Log().Warnf("Unable to parse document: %v", err)
 		return ctx.String(http.StatusBadRequest, err.Error())
 	}
-	outputDocument, err := a.Service.AddDocumentWithContents(time.Unix(0, inputDocument.Timestamp), inputDocument.Type, inputDocument.Contents)
+	outputDocument, err := a.Service.AddDocumentWithContents(model.UnmarshalDocumentTime(inputDocument.Timestamp), inputDocument.Type, inputDocument.Contents)
 	if err != nil {
 		logging.Log().Warnf("Unable to add document: %v", err)
 		return ctx.String(http.StatusInternalServerError, err.Error())
@@ -101,7 +100,7 @@ func (a ApiWrapper) AddDocument(ctx echo.Context) error {
 func writeDocument(ctx echo.Context, statusCode int, document model.Document) error {
 	return ctx.JSON(statusCode, Document{
 		Hash:      document.Hash.String(),
-		Timestamp: document.Timestamp.UnixNano(),
+		Timestamp: model.MarshalDocumentTime(document.Timestamp),
 		Type:      document.Type,
 	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -49,7 +49,7 @@ func TestApiWrapper_AddDocument(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		var networkClient = pkg.NewMockNetworkClient(mockCtrl)
 		e, wrapper := initMockEcho(networkClient)
-		networkClient.EXPECT().AddDocumentWithContents(document.Timestamp, document.Type, documentContents).Return(&document, nil)
+		networkClient.EXPECT().AddDocumentWithContents(document.Timestamp.UTC(), document.Type, documentContents).Return(&document, nil)
 
 		input := DocumentWithContents{
 			Contents:  documentContents,

--- a/api/client.go
+++ b/api/client.go
@@ -99,7 +99,7 @@ func (hb HttpClient) AddDocumentWithContents(timestamp time.Time, docType string
 	defer cancel()
 	res, err := hb.client().AddDocument(ctx, AddDocumentJSONRequestBody{
 		Contents:  contents,
-		Timestamp: timestamp.UnixNano(),
+		Timestamp: model.MarshalDocumentTime(timestamp),
 		Type:      docType,
 	})
 	if err != nil {
@@ -154,7 +154,7 @@ func testResponseCode(expectedStatusCode int, response *http.Response) error {
 }
 
 func (d *Document) fromModel(document model.Document) {
-	d.Timestamp = document.Timestamp.UnixNano()
+	d.Timestamp = model.MarshalDocumentTime(document.Timestamp)
 	d.Hash = document.Hash.String()
 	d.Type = document.Type
 }
@@ -164,6 +164,6 @@ func (d Document) toModel() model.Document {
 	return model.Document{
 		Hash:      hash,
 		Type:      d.Type,
-		Timestamp: time.Unix(0, d.Timestamp),
+		Timestamp: model.UnmarshalDocumentTime(d.Timestamp),
 	}
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -56,7 +56,7 @@ func TestDocument_toModel(t *testing.T) {
 	expected := model.Document{
 		Hash:      test.StringToHash("37076f2cbe014a109d79b61ae9c7191f4cc57afc"),
 		Type:      "test",
-		Timestamp: time.Unix(0, 1591255458635412720),
+		Timestamp: time.Unix(0, 1591255458635412720).UTC(),
 	}
 	actual := Document{
 		Hash:      "37076f2cbe014a109d79b61ae9c7191f4cc57afc",

--- a/pkg/documentlog/impl.go
+++ b/pkg/documentlog/impl.go
@@ -143,9 +143,10 @@ func (dl *documentLog) addDocument(document model.Document) error {
 	}
 	if existing != nil {
 		// Hash already present, but check if the timestamp matches, just to be sure
-		t := existing.Document.Timestamp.UnixNano()
-		if t != document.Timestamp.UnixNano() {
-			return fmt.Errorf("document hash %s with timestamp %d is already present with different timestamp (%d)", document.Hash, document.Timestamp.UnixNano(), t)
+		existingTime := model.MarshalDocumentTime(existing.Document.Timestamp)
+		currentTime := model.MarshalDocumentTime(document.Timestamp)
+		if existingTime != currentTime {
+			return fmt.Errorf("document hash %s with timestamp %d is already present with different timestamp (%d)", document.Hash, currentTime, existingTime)
 		}
 		return nil
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -165,7 +165,7 @@ func CalculateDocumentHash(docType string, timestamp time.Time, contents []byte)
 		DocType   string `json:"type"`
 		Timestamp int64  `json:"timestamp"`
 		Contents  []byte `json:"contents"`
-	}{docType, timestamp.UTC().UnixNano(), contents})
+	}{docType, MarshalDocumentTime(timestamp), contents})
 	return sha1.Sum(data)
 }
 

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -1,0 +1,21 @@
+package model
+
+import "time"
+
+// MarshalDocumentTime converts a document's time.Time to unix nanoseconds.
+func MarshalDocumentTime(ts time.Time) int64 {
+	if ts.IsZero() {
+		return 0
+	} else {
+		return ts.UTC().UnixNano()
+	}
+}
+
+// UnmarshalDocumentTime converts a document's timestamp in unix nanoseconds to time.Time.
+func UnmarshalDocumentTime(ns int64) time.Time {
+	if ns == 0 {
+		return time.Time{}
+	} else {
+		return time.Unix(0, ns).UTC()
+	}
+}

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -13,7 +13,7 @@ func MarshalDocumentTime(ts time.Time) int64 {
 
 // UnmarshalDocumentTime converts a document's timestamp in unix nanoseconds to time.Time.
 func UnmarshalDocumentTime(ns int64) time.Time {
-	if ns == 0 {
+	if ns <= 0 {
 		return time.Time{}
 	} else {
 		return time.Unix(0, ns).UTC()

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -13,5 +13,6 @@ func TestMarshalDocumentTime(t *testing.T) {
 
 func TestUnmarshalDocumentTime(t *testing.T) {
 	assert.True(t, UnmarshalDocumentTime(0).IsZero())
+	assert.True(t, UnmarshalDocumentTime(-1).IsZero())
 	assert.Equal(t, time.Date(2020, 10, 20, 20, 30, 0, 0, time.UTC), UnmarshalDocumentTime(1603225800000000000))
 }

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestMarshalDocumentTime(t *testing.T) {
+	assert.Equal(t, int64(0), MarshalDocumentTime(time.Time{}))
+	assert.Equal(t, int64(1603225800000000000), MarshalDocumentTime(time.Date(2020, 10, 20, 20, 30, 0, 0, time.UTC)))
+}
+
+func TestUnmarshalDocumentTime(t *testing.T) {
+	assert.True(t, UnmarshalDocumentTime(0).IsZero())
+	assert.Equal(t, time.Date(2020, 10, 20, 20, 30, 0, 0, time.UTC), UnmarshalDocumentTime(1603225800000000000))
+}

--- a/pkg/network.go
+++ b/pkg/network.go
@@ -190,7 +190,7 @@ func (n *Network) ListDocuments() ([]model.DocumentDescriptor, error) {
 }
 
 func (n *Network) AddDocumentWithContents(timestamp time.Time, docType string, contents []byte) (*model.Document, error) {
-	log.Log().Infof("Adding document (timestamp=%d,type=%s,content length=%d)", timestamp.UnixNano(), docType, len(contents))
+	log.Log().Infof("Adding document (timestamp=%d,type=%s,content length=%d)", model.MarshalDocumentTime(timestamp), docType, len(contents))
 	// TODO: Validation
 	return n.documentLog.AddDocumentWithContents(timestamp, docType, bytes.NewReader(contents))
 }

--- a/pkg/proto/handlers.go
+++ b/pkg/proto/handlers.go
@@ -5,7 +5,6 @@ import (
 	log "github.com/nuts-foundation/nuts-network/logging"
 	"github.com/nuts-foundation/nuts-network/network"
 	"github.com/nuts-foundation/nuts-network/pkg/model"
-	"time"
 )
 
 func (p *protocol) handleAdvertHash(peer model.PeerID, advertHash *network.AdvertHash) {
@@ -62,13 +61,15 @@ func (p *protocol) handleHashList(peer model.PeerID, hashList *network.HashList)
 		hash := model.SliceToHash(current.Hash)
 		if hash.Empty() {
 			log.Log().Warn("Received document doesn't contain a hash, skipping.")
+			continue
 		}
 		if current.Time == 0 {
 			log.Log().Warnf("Received document doesn't contain a timestamp, skipping (hash=%s).", hash)
+			continue
 		}
 		documents[i] = model.Document{
 			Type:      current.Type,
-			Timestamp: time.Unix(0, current.Time),
+			Timestamp: model.UnmarshalDocumentTime(current.Time),
 			Hash:      hash,
 		}
 	}
@@ -112,7 +113,7 @@ func (p *protocol) handleHashListQuery(peer model.PeerID) error {
 	}
 	for i, document := range documents {
 		msg.HashList.Hashes[i] = &network.Document{
-			Time: document.Timestamp.UnixNano(),
+			Time: model.MarshalDocumentTime(document.Timestamp),
 			Hash: document.Hash.Slice(),
 			Type: document.Type,
 		}

--- a/pkg/proto/handlers.go
+++ b/pkg/proto/handlers.go
@@ -74,8 +74,12 @@ func (p *protocol) handleHashList(peer model.PeerID, hashList *network.HashList)
 		}
 	}
 	for _, document := range documents {
+		if p.documentIgnoreList[document.Hash] {
+			continue
+		}
 		if err := p.checkDocumentOnLocalNode(peer, document); err != nil {
-			log.Log().Errorf("Error while checking peer document on local node (peer=%s, document=%s): %v", peer, document.Hash, err)
+			log.Log().Errorf("Error while checking peer document on local node, ignoring it until next restart (peer=%s, document=%s): %v", peer, document.Hash, err)
+			p.documentIgnoreList[document.Hash] = true
 		}
 	}
 	return nil
@@ -93,7 +97,7 @@ func (p *protocol) checkDocumentOnLocalNode(peer model.PeerID, peerDocument mode
 			return err
 		}
 	}
-	// TODO: Currently we send the query to the peer that send us the hash, but this peer might not have the
+	// TODO: Currently we send the query to the peer that sent us the hash, but this peer might not have the
 	//   document contents. We need a smarter way to get it from a peer who does.
 	log.Log().Infof("Received document hash from peer that we don't have yet or we're missing its contents, will query it (peer=%s,hash=%s)", peer, peerDocument.Hash)
 	responseMsg := createMessage()

--- a/pkg/proto/impl.go
+++ b/pkg/proto/impl.go
@@ -36,6 +36,9 @@ type protocol struct {
 	receivedDocumentHashes    *chanPeerHashQueue
 	peerHashes                map[model.PeerID]model.Hash
 
+	// documentIgnoreList contains hashes of documents that are invalid and shouldn't be retrieved from peers.
+	documentIgnoreList 		  map[model.Hash]bool
+
 	// Cache statistics to avoid having to lock precious resources
 	peerConsistencyHashStatistic peerConsistencyHashStatistic
 	newPeerHashChannel           chan PeerHash
@@ -54,7 +57,7 @@ func NewProtocol() Protocol {
 
 		peerHashes:         make(map[model.PeerID]model.Hash),
 		newPeerHashChannel: make(chan PeerHash, 100),
-
+		documentIgnoreList: make(map[model.Hash]bool, 0),
 		peerConsistencyHashStatistic: newPeerConsistencyHashStatistic(),
 	}
 	return p


### PR DESCRIPTION
Fixes following issues:

1. Converting a zero timestamp (`time.IsZero() == true`) to unix nanos and back leads to invalid timestamps. Added marshal/unmarshal util functions for handling this properly.
2. When peers send us documents with invalid timestamps we shouldn't keep retrieving them but ignore them.